### PR TITLE
Support select_value method for exists?

### DIFF
--- a/lib/distribute_reads.rb
+++ b/lib/distribute_reads.rb
@@ -1,4 +1,5 @@
 require "makara"
+require 'active_record/connection_adapters/makara_abstract_adapter'
 require "distribute_reads/appropriate_pool"
 require "distribute_reads/cache_store"
 require "distribute_reads/global_methods"
@@ -70,6 +71,7 @@ module DistributeReads
 end
 
 Makara::Proxy.send :prepend, DistributeReads::AppropriatePool
+ActiveRecord::ConnectionAdapters::MakaraAbstractAdapter.send :hijack_method, :select_value
 Object.send :include, DistributeReads::GlobalMethods
 
 ActiveSupport.on_load(:active_job) do


### PR DESCRIPTION
### What
Hijack the `select_value` method on the Postgres adapter.

### Why
Calling `exists?` within a `distribute_reads` block will not send the query to replica as expected.

### Notes
This happens because `exists?` calls `select_value` instead of `select_rows`. Normally, `select_value` will call `select_rows`, but the Postgres adapter overrides this behavior.