### PR TITLE
update readme with a note about lazy load

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ By default, all reads go to the primary instance. To use the replica, do:
 ```ruby
 distribute_reads { User.count }
 ```
+**Note:** ActiveRecord Lazy loading might delay the execution of the query outside of the distribute_reads block. in such case the primary database will be used
 
 Works with multiple queries as well.
 


### PR DESCRIPTION
We encountered a confusing situation when using the gem.
when using server side rendering the actual query ran outside of the block which caused the query to run on the primary database.
Adding a note in the documentation might be enough but maybe we can "mark" the activerecord relation and run it on the replica even if the query ran outside of the distribute_reads block