### PR TITLE
 Make logging optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ distribute_reads(failover: false) do
 end
 ```
 
+### Non-critical Logging
+
+Logging is enabled by default. To turn off non-critical logging, you can pass it as a param.
+
+```ruby
+distribute_reads(logging: false) do
+  # ...
+end
+```
+
 ### Default Options
 
 Change the defaults
@@ -133,7 +143,8 @@ Change the defaults
 ```ruby
 DistributeReads.default_options = {
   lag_failover: true,
-  failover: false
+  failover: false,
+  logging: true
 }
 ```
 

--- a/lib/distribute_reads.rb
+++ b/lib/distribute_reads.rb
@@ -16,7 +16,8 @@ module DistributeReads
   self.by_default = false
   self.default_options = {
     failover: true,
-    lag_failover: false
+    lag_failover: false,
+    logging: true
   }
 
   def self.replication_lag(connection: nil)
@@ -83,6 +84,7 @@ module DistributeReads
   end
 
   def self.log(message)
+    return unless Thread.current[:distribute_reads][:logging]
     warn "[distribute_reads] #{message}"
   end
 

--- a/lib/distribute_reads/global_methods.rb
+++ b/lib/distribute_reads/global_methods.rb
@@ -3,7 +3,7 @@ module DistributeReads
     def distribute_reads(**options)
       raise ArgumentError, "Missing block" unless block_given?
 
-      unknown_keywords = options.keys - [:failover, :lag_failover, :lag_on, :max_lag, :primary, :replica]
+      unknown_keywords = options.keys - [:failover, :lag_failover, :lag_on, :max_lag, :primary, :replica, :logging]
       raise ArgumentError, "Unknown keywords: #{unknown_keywords.join(", ")}" if unknown_keywords.any?
 
       options = DistributeReads.default_options.merge(options)

--- a/lib/distribute_reads/global_methods.rb
+++ b/lib/distribute_reads/global_methods.rb
@@ -13,7 +13,8 @@ module DistributeReads
         Thread.current[:distribute_reads] = {
           failover: options[:failover],
           primary: options[:primary],
-          replica: options[:replica]
+          replica: options[:replica],
+          logging: options[:logging]
         }
 
         # TODO ensure same connection is used to test lag and execute queries


### PR DESCRIPTION
It would be useful to have an option to turn off logging. 

This can be especially valuable in large codebases (eg: 🥕) where millions of these (extraneous) lines are written to the log every day. 