### PR TITLE
logic  for negative 1 replica lag

### DIFF
--- a/lib/distribute_reads.rb
+++ b/lib/distribute_reads.rb
@@ -86,8 +86,8 @@ module DistributeReads
         else
           status = connection.exec_query("SHOW SLAVE STATUS").to_hash.first
           if status
-            if status["Seconds_Behind_Master"].to_s == 'NULL'
-              -1.0
+            if status["Seconds_Behind_Master"].nil?
+              nil
             else
               status["Seconds_Behind_Master"].to_f
             end

--- a/lib/distribute_reads.rb
+++ b/lib/distribute_reads.rb
@@ -85,7 +85,11 @@ module DistributeReads
           status ? status["Replica_lag_in_msec"].to_f / 1000.0 : 0.0
         else
           status = connection.exec_query("SHOW SLAVE STATUS").to_hash.first
-          status ? status["Seconds_Behind_Master"].to_f : 0.0
+          if status["Seconds_Behind_Master"].to_s == 'NULL'
+            status = -1
+          else
+            status ? status["Seconds_Behind_Master"].to_f : 0.0
+          end
         end
       ensure
         Thread.current[:distribute_reads][:replica] = replica_value

--- a/lib/distribute_reads.rb
+++ b/lib/distribute_reads.rb
@@ -85,10 +85,14 @@ module DistributeReads
           status ? status["Replica_lag_in_msec"].to_f / 1000.0 : 0.0
         else
           status = connection.exec_query("SHOW SLAVE STATUS").to_hash.first
-          if status["Seconds_Behind_Master"].to_s == 'NULL'
-            status = -1
+          if status
+            if status["Seconds_Behind_Master"].to_s == 'NULL'
+              -1.0
+            else
+              status["Seconds_Behind_Master"].to_f
+            end
           else
-            status ? status["Seconds_Behind_Master"].to_f : 0.0
+            0.0
           end
         end
       ensure

--- a/lib/distribute_reads/global_methods.rb
+++ b/lib/distribute_reads/global_methods.rb
@@ -21,10 +21,10 @@ module DistributeReads
         if max_lag && !options[:primary]
           Array(options[:lag_on] || [ActiveRecord::Base]).each do |base_model|
             current_lag = DistributeReads.lag(connection: base_model.connection)
-            if current_lag > max_lag || current_lag == -1.0
+            if current_lag.nil? || current_lag > max_lag
               message = "Replica lag over #{max_lag} seconds#{options[:lag_on] ? " on #{base_model.name} connection" : ""}"
-              if current_lag == -1.0
-                message = "Replica lag is -1 on #{base_model.name}"
+              if current_lag.nil?
+                message = "Replica lag is nil on #{base_model.name}"
               end
 
               if options[:lag_failover]

--- a/lib/distribute_reads/global_methods.rb
+++ b/lib/distribute_reads/global_methods.rb
@@ -20,9 +20,10 @@ module DistributeReads
         max_lag = options[:max_lag]
         if max_lag && !options[:primary]
           Array(options[:lag_on] || [ActiveRecord::Base]).each do |base_model|
-            if DistributeReads.lag(connection: base_model.connection) > max_lag or DistributeReads.lag(connection: base_model.connection) == -1
+            current_lag = DistributeReads.lag(connection: base_model.connection)
+            if current_lag > max_lag || current_lag == -1
               message = "Replica lag over #{max_lag} seconds#{options[:lag_on] ? " on #{base_model.name} connection" : ""}"
-              if DistributeReads.lag(connection: base_model.connection) == -1
+              if current_lag == -1
                 message = "Replica lag is -1 on #{base_model.name}"
               end
 

--- a/lib/distribute_reads/global_methods.rb
+++ b/lib/distribute_reads/global_methods.rb
@@ -21,9 +21,9 @@ module DistributeReads
         if max_lag && !options[:primary]
           Array(options[:lag_on] || [ActiveRecord::Base]).each do |base_model|
             current_lag = DistributeReads.lag(connection: base_model.connection)
-            if current_lag > max_lag || current_lag == -1
+            if current_lag > max_lag || current_lag == -1.0
               message = "Replica lag over #{max_lag} seconds#{options[:lag_on] ? " on #{base_model.name} connection" : ""}"
-              if current_lag == -1
+              if current_lag == -1.0
                 message = "Replica lag is -1 on #{base_model.name}"
               end
 

--- a/lib/distribute_reads/global_methods.rb
+++ b/lib/distribute_reads/global_methods.rb
@@ -20,7 +20,7 @@ module DistributeReads
         max_lag = options[:max_lag]
         if max_lag && !options[:primary]
           Array(options[:lag_on] || [ActiveRecord::Base]).each do |base_model|
-            if DistributeReads.lag(connection: base_model.connection) > max_lag
+            if DistributeReads.lag(connection: base_model.connection) > max_lag or DistributeReads.lag(connection: base_model.connection) == -1
               message = "Replica lag over #{max_lag} seconds#{options[:lag_on] ? " on #{base_model.name} connection" : ""}"
 
               if options[:lag_failover]

--- a/lib/distribute_reads/global_methods.rb
+++ b/lib/distribute_reads/global_methods.rb
@@ -22,6 +22,9 @@ module DistributeReads
           Array(options[:lag_on] || [ActiveRecord::Base]).each do |base_model|
             if DistributeReads.lag(connection: base_model.connection) > max_lag or DistributeReads.lag(connection: base_model.connection) == -1
               message = "Replica lag over #{max_lag} seconds#{options[:lag_on] ? " on #{base_model.name} connection" : ""}"
+              if DistributeReads.lag(connection: base_model.connection) == -1
+                message = "Replica lag is -1 on #{base_model.name}"
+              end
 
               if options[:lag_failover]
                 # TODO possibly per connection

--- a/test/distribute_reads_test.rb
+++ b/test/distribute_reads_test.rb
@@ -78,13 +78,13 @@ class DistributeReadsTest < Minitest::Test
 
   def test_lag_negative_one
     error = assert_raises DistributeReads::TooMuchLag do
-      with_lag(-1) do
+      with_lag(nil) do
         distribute_reads(max_lag: 1) do
           assert_replica
         end
       end
     end
-    assert_equal "Replica lag is -1 on ActiveRecord::Base", error.message
+    assert_equal "Replica lag is nil on ActiveRecord::Base", error.message
   end
 
   def test_max_lag_under_not_stubbed
@@ -102,7 +102,7 @@ class DistributeReadsTest < Minitest::Test
   end
 
   def test_lag_failover_negative_one
-    with_lag(-1) do
+    with_lag(nil) do
       distribute_reads(max_lag: 1, lag_failover: true) do
         assert_primary
       end

--- a/test/distribute_reads_test.rb
+++ b/test/distribute_reads_test.rb
@@ -76,6 +76,17 @@ class DistributeReadsTest < Minitest::Test
     end
   end
 
+  def test_lag_negative_one
+    error = assert_raises DistributeReads::TooMuchLag do
+      with_lag(-1) do
+        distribute_reads(max_lag: 1) do
+          assert_replica
+        end
+      end
+    end
+    assert_equal "Replica lag is -1 on ActiveRecord::Base", error.message
+  end
+
   def test_max_lag_under_not_stubbed
     distribute_reads(max_lag: 1) do
       assert_replica
@@ -84,6 +95,14 @@ class DistributeReadsTest < Minitest::Test
 
   def test_lag_failover
     with_lag(2) do
+      distribute_reads(max_lag: 1, lag_failover: true) do
+        assert_primary
+      end
+    end
+  end
+
+  def test_lag_failover_negative_one
+    with_lag(-1) do
       distribute_reads(max_lag: 1, lag_failover: true) do
         assert_primary
       end


### PR DESCRIPTION
In AWS RDS, it is possible to have negative one replica lag, which means the replica is up but not replicating. I think the distribute reads should also failover in this case. This PR addresses this issue. 