### PR TITLE
Create verbose debug mode to cull log noise.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /spec/reports/
 /tmp/
 *.lock
+.idea/

--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ DistributeReads.logger = Logger.new(STDERR)
 
 Or use `nil` to disable logging.
 
+### Debuging
+Some warnings are only logged once, or are silenced.  To get verbose logging for debugging, use the environment variable:
+
+```bash
+DISTRIBUTE_READS_VERBOSE=true
+```
+
 ## Distribute Reads by Default
 
 At some point, you may wish to distribute reads by default.

--- a/lib/distribute_reads.rb
+++ b/lib/distribute_reads.rb
@@ -36,7 +36,10 @@ module DistributeReads
 
     replica_pool = connection.instance_variable_get(:@slave_pool)
     if replica_pool && replica_pool.connections.size > 1
-      log "Multiple replicas available, lag only reported for one"
+      if ENV["DISTRIBUTE_READS_VERBOSE"].present? || self.already_logged_multi_replica_warning != true
+        log "Multiple replicas available, lag only reported for one"
+        self.already_logged_multi_replica_warning = true
+      end
     end
 
     with_replica do

--- a/lib/distribute_reads/global_methods.rb
+++ b/lib/distribute_reads/global_methods.rb
@@ -35,6 +35,7 @@ module DistributeReads
                 elsif !current_lag
                   "No replicas available for lag check"
                 else
+                  is_lag_over_max = true
                   "Replica lag over #{max_lag} seconds"
                 end
 
@@ -44,7 +45,7 @@ module DistributeReads
                 # TODO possibly per connection
                 Thread.current[:distribute_reads][:primary] = true
                 Thread.current[:distribute_reads][:replica] = false
-                DistributeReads.log "#{message}. Falling back to master pool."
+                DistributeReads.log "#{message}. Falling back to master pool." unless is_lag_over_max && max_lag == 0 && !ENV["DISTRIBUTE_READS_VERBOSE"].present?
                 break
               else
                 raise DistributeReads::TooMuchLag, message


### PR DESCRIPTION
Under heavy use, this library ends up sending an enormous number of logs.  Many of them are of no use.  The two in this PR are the worst offenders:

* `[distribute_reads] Multiple replicas available, lag only reported for one`.  This needs only be logged once per process IMO
* `[distribute_reads] Replica lag over 0 seconds. Falling back to master pool.`  When we are at max lag of 0 seconds then we are basically not using the functionality, and no not need this message, much less 1x/5seconds under our current load.

Added to Readme how to get these logs back using environment Variable.

Having trouble setting up mysql2 gem on my mac at the moment, tests have not been run.