### PR TITLE
Eager load dataset instead of logging to stdout

### DIFF
--- a/lib/distribute_reads/global_methods.rb
+++ b/lib/distribute_reads/global_methods.rb
@@ -54,7 +54,7 @@ module DistributeReads
         end
 
         value = yield
-        DistributeReads.log "Call `to_a` inside block to execute query on replica" if value.is_a?(ActiveRecord::Relation) && !previous_value
+        value.load if value.is_a?(ActiveRecord::Relation) && !previous_value
         value
       ensure
         Thread.current[:distribute_reads] = previous_value

--- a/test/distribute_reads_test.rb
+++ b/test/distribute_reads_test.rb
@@ -148,11 +148,11 @@ class DistributeReadsTest < Minitest::Test
   end
 
   def test_relation
-    assert_log "Call `to_a` inside block to execute query on replica" do
-      distribute_reads do
-        User.all
-      end
+    value = distribute_reads do
+      User.all
     end
+
+    assert_equal value.loaded?, true
   end
 
   def test_failover_true


### PR DESCRIPTION
Instead of printing
> Call `to_a` inside block to execute query on replica

execute the query on replica :)